### PR TITLE
Implement multi-line REPL for loops (Fixes #6).

### DIFF
--- a/cli_loop_proof.gola
+++ b/cli_loop_proof.gola
@@ -1,0 +1,2 @@
+bolte thak i [0] -> [2] [i++] :
+kemon achis i


### PR DESCRIPTION
**Fixes #6**

### Feat: Multi-Line Loop Body Reading in CLI (REPL)

This pull request resolves Issue #6 by implementing support for **multi-line statements** in the CLI/REPL. The interpreter now recognizes an incomplete statement (like a loop or conditional header ending with a colon `:`) and correctly transitions to a continuation line (`...`), replicating the smooth behavior of a Python-style REPL.

This functionality has been verified for the `bolte thak` loop structure.

---

Additional Stability Fixes

This PR also includes two stability improvements:

* **Comparison Operators:** Preserved comparison operators (e.g., `==`, `!=`) during the code normalization process, preventing them from being incorrectly interpreted as a single assignment operator (`=`).
* **Input Stability:** Switched to using the `bufio` package for `bol` (user input) operations to ensure proper handling and prevent potential conflicts when mixing standard input readers.
<img width="873" height="556" alt="issue6_fixes" src="https://github.com/user-attachments/assets/0a689958-595f-4ede-93f5-7a952fe3ac4f" />
proof is added
